### PR TITLE
Updates to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #### Main
 
-provision: tf.apply twitter-forwarder.build streams.build connectors.add.both twitter-forwarder.start
+provision: twitter-forwarder.build streams.build tweets-transformation.build tf.apply connectors.add.both twitter-forwarder.start
 
 tf.apply:
 	terraform apply --auto-approve terraform

--- a/tweets-transformation/requirements.txt
+++ b/tweets-transformation/requirements.txt
@@ -1,7 +1,7 @@
 avro-python3==1.9.0
 certifi==2019.6.16
 chardet==3.0.4
-confluent-kafka==1.1.0
+confluent-kafka
 fastavro==0.22.3
 Flask==1.1.1
 idna==2.8


### PR DESCRIPTION
This PR is doing two things - 
 
- Updating  `Makefile` to build images first before doing `terraform apply`. Also, it was not building `tweets-transformation` image.

-  Removing `confluent-kafka` version as it was throwing an error (screen shot attached) when I built the image 

<img width="1448" alt="Screen Shot 2020-02-04 at 5 11 56 PM" src="https://user-images.githubusercontent.com/4614294/73802483-a3e8ac80-4772-11ea-8a3a-6042ad48fc12.png">



